### PR TITLE
Add stubbing instructions to error message

### DIFF
--- a/lib/miniproxy/remote.rb
+++ b/lib/miniproxy/remote.rb
@@ -77,6 +77,7 @@ module MiniProxy
         res.status = 200
         res.body = ""
         STDOUT.puts "WARN: external request to #{req.host}#{req.path} not mocked"
+        STDOUT.puts %Q{Stub with: MiniProxy::Server.stub_request(method: "#{req.request_method}", url: "#{req.host}#{req.path}")}
       end
     end
 

--- a/spec/lib/miniproxy/remote_spec.rb
+++ b/spec/lib/miniproxy/remote_spec.rb
@@ -1,1 +1,19 @@
 require "miniproxy/remote"
+
+describe MiniProxy::Remote do
+  describe "#handler" do
+    let(:remote) { MiniProxy::Remote.new }
+
+    context "when the request has not been mocked" do
+      let(:req) { double(:request, request_method: 'GET', host: 'example.com', path: '/') }
+      let(:res) { WEBrick::HTTPResponse.new(WEBrick::Config::HTTP) }
+
+      it "outputs an error message" do
+        expect(STDOUT).to receive(:puts).with("WARN: external request to example.com/ not mocked")
+        expect(STDOUT).to receive(:puts).with(%q(Stub with: MiniProxy::Server.stub_request(method: "GET", url: "example.com/")))
+
+        remote.handler(req, res)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Make it as easy as possible to stub requests by adding sample code to the "unmocked request" error message.