### PR TITLE
Add integration specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: ruby
 rvm:
   - 2.5
-script: bundle exec rspec
+script: xvfb-run bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: ruby
 rvm:
   - 2.5
+before_install:
+  - wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz
+  - mkdir geckodriver
+  - tar -xzf geckodriver-v0.21.0-linux64.tar.gz -C geckodriver
+  - export PATH=$PATH:$PWD/geckodriver
 script: xvfb-run bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
   - 2.5
+addons:
+  firefox: "60.0"
 before_install:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz
   - mkdir geckodriver

--- a/README.md
+++ b/README.md
@@ -46,8 +46,20 @@ In your specs, to stub a request:
     })
 
 
-## Testing MiniProxy itself
+## Developing
 
-Tests are run via RSpec:
+Pull requests are welcome, we try our best to stick with [semver](https://semver.org/), avoid breaking changes to the API whenever possible.
 
-    rspec spec
+Run the unit tests:
+
+    bundle exec rspec spec/lib
+
+Integration tests use capybara/selenium/firefox. So you'll need a modern version of Firefox and Geckodriver on your system PATH. They can be run like so:
+
+    bundle exec rspec spec/integration
+
+Alternatively you can just rely on CI to run the integration tests.
+
+And of course, to run all the tests:
+
+    bundle exec rspec

--- a/miniproxy.gemspec
+++ b/miniproxy.gemspec
@@ -7,4 +7,6 @@ spec = Gem::Specification.new do |s|
   s.files = `git ls-files -- lib/*`.split("\n")
 
   s.add_development_dependency 'rspec'
+  s.add_development_dependency 'capybara'
+  s.add_development_dependency 'selenium-webdriver'
 end

--- a/spec/integration/stub_requests_spec.rb
+++ b/spec/integration/stub_requests_spec.rb
@@ -1,0 +1,74 @@
+require "capybara"
+require "miniproxy"
+require "selenium-webdriver"
+
+firefox_profile = Selenium::WebDriver::Firefox::Profile.new
+firefox_profile.assume_untrusted_certificate_issuer = true
+firefox_profile.proxy = Selenium::WebDriver::Proxy.new(
+  http: "#{MiniProxy::Server.host}:#{MiniProxy::Server.port}",
+  ssl: "#{MiniProxy::Server.host}:#{MiniProxy::Server.port}"
+)
+
+firefox_options = Selenium::WebDriver::Firefox::Options.new(profile: firefox_profile)
+firefox_options.headless!
+
+firefox_caps = Selenium::WebDriver::Remote::Capabilities.firefox(accept_insecure_certs: true)
+
+Capybara.register_driver :firefox do |app|
+  Capybara::Selenium::Driver.new(app, desired_capabilities: firefox_caps, options: firefox_options)
+end
+
+RSpec.describe "miniproxy" do
+  let(:session) { Capybara::Session.new(:firefox) }
+
+  describe "http request" do
+
+    context "stubbed" do
+      before do
+        MiniProxy::Server.stub_request(method: "GET", url: /example.com/, response: { body: "foo" })
+      end
+
+      after do
+        MiniProxy::Server.reset
+      end
+
+      it "intercepts the request and returns the mock response" do
+        session.visit("http://example.com/resource.txt")
+        expect(session).to have_content "foo"
+      end
+    end
+
+    context "not stubbed" do
+      it "intercepts the request and prints a warning to stdout", :pending do
+        expect {
+          session.visit("http://example.com")
+        }.to output(/WARN/).to_stdout_from_any_process
+      end
+    end
+  end
+
+  describe "https request" do
+    context "stubbed" do
+      before do
+        MiniProxy::Server.stub_request(method: "GET", url: /example.com/, response: { body: "foo" })
+      end
+
+      after do
+        MiniProxy::Server.reset
+      end
+
+      it "intercepts the request and returns the mock response" do
+        session.visit("https://example.com/resource.txt")
+        expect(session).to have_content "foo"
+      end
+    end
+
+    context "not stubbed" do
+      it "intercepts the request and prints a warning to stdout", :pending do
+        expect {
+          session.visit("http://example.com")
+        }.to output(/WARN/).to_stdout_from_any_process
+      end
+    end
+  end
+end

--- a/spec/integration/stub_requests_spec.rb
+++ b/spec/integration/stub_requests_spec.rb
@@ -1,6 +1,5 @@
 require "capybara"
 require "miniproxy"
-require "selenium-webdriver"
 require "support/capybara_driver"
 
 RSpec.describe "miniproxy" do

--- a/spec/integration/stub_requests_spec.rb
+++ b/spec/integration/stub_requests_spec.rb
@@ -1,22 +1,7 @@
 require "capybara"
 require "miniproxy"
 require "selenium-webdriver"
-
-firefox_profile = Selenium::WebDriver::Firefox::Profile.new
-firefox_profile.assume_untrusted_certificate_issuer = true
-firefox_profile.proxy = Selenium::WebDriver::Proxy.new(
-  http: "#{MiniProxy::Server.host}:#{MiniProxy::Server.port}",
-  ssl: "#{MiniProxy::Server.host}:#{MiniProxy::Server.port}"
-)
-
-firefox_options = Selenium::WebDriver::Firefox::Options.new(profile: firefox_profile)
-firefox_options.headless!
-
-firefox_caps = Selenium::WebDriver::Remote::Capabilities.firefox(accept_insecure_certs: true)
-
-Capybara.register_driver :firefox do |app|
-  Capybara::Selenium::Driver.new(app, desired_capabilities: firefox_caps, options: firefox_options)
-end
+require "support/capybara_driver"
 
 RSpec.describe "miniproxy" do
   let(:session) { Capybara::Session.new(:firefox) }

--- a/spec/support/capybara_driver.rb
+++ b/spec/support/capybara_driver.rb
@@ -1,0 +1,15 @@
+firefox_profile = Selenium::WebDriver::Firefox::Profile.new
+firefox_profile.assume_untrusted_certificate_issuer = true
+firefox_profile.proxy = Selenium::WebDriver::Proxy.new(
+  http: "#{MiniProxy::Server.host}:#{MiniProxy::Server.port}",
+  ssl: "#{MiniProxy::Server.host}:#{MiniProxy::Server.port}"
+)
+
+firefox_options = Selenium::WebDriver::Firefox::Options.new(profile: firefox_profile)
+firefox_options.headless!
+
+firefox_caps = Selenium::WebDriver::Remote::Capabilities.firefox(accept_insecure_certs: true)
+
+Capybara.register_driver :firefox do |app|
+  Capybara::Selenium::Driver.new(app, desired_capabilities: firefox_caps, options: firefox_options)
+end

--- a/spec/support/capybara_driver.rb
+++ b/spec/support/capybara_driver.rb
@@ -1,3 +1,6 @@
+require "capybara"
+require "selenium-webdriver"
+
 firefox_profile = Selenium::WebDriver::Firefox::Profile.new
 firefox_profile.assume_untrusted_certificate_issuer = true
 firefox_profile.proxy = Selenium::WebDriver::Proxy.new(


### PR DESCRIPTION
They aren't perfect, but will offer a decent enough safety net while we're making changes separately from the main app.

I'd originally used Chrome, but got stung by a nasty gotcha where the `--headless` flag causes other arguments to be completely ignored, so Miniproxy wasn't working as expected. This is probably going to cause issues in TC. So we might want to document/investigate this point further.

Also the warning output is not being captured by rspec for some reason, so that also needs investigation. Those specs are marked as pending.