### PR TITLE
Add method to ignore all requests between specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ Make sure that RSpec resets the server after each test, and stops the server whe
     require "miniproxy"
 
     RSpec.configure do |config|
-      config.after :each, type: :feature do
+      config.before :each, type: :feature do
         MiniProxy::Server.reset
+      end
+
+      config.after :each, type: :feature do
+        # Ignore any requests made between specs
+        MiniProxy::Server.ignore_all_requests
       end
 
       config.after :suite do

--- a/lib/miniproxy/server.rb
+++ b/lib/miniproxy/server.rb
@@ -42,6 +42,14 @@ module MiniProxy
       ENV.fetch("MINI_PROXY_HOST", "127.0.0.1")
     end
 
+    def self.ignore_all_requests
+      reset
+
+      %w(GET POST PUT PATCH DELETE).each do |method|
+        stub_request(method: method, url: /.*/)
+      end
+    end
+
     def self.stub_request(method:, url:, response: {})
       remote.stub_request(method: method, url: url, response: response)
     end

--- a/spec/integration/ignore_all_requests_spec.rb
+++ b/spec/integration/ignore_all_requests_spec.rb
@@ -1,0 +1,46 @@
+require "capybara"
+require "miniproxy"
+require "support/capybara_driver"
+
+RSpec.describe "miniproxy" do
+  let(:session) { Capybara::Session.new(:firefox) }
+
+  describe "ignoring all requests" do
+    context "without any previous stubs" do
+      before do
+        MiniProxy::Server.ignore_all_requests
+      end
+
+      after do
+        MiniProxy::Server.reset
+      end
+
+      it "intercepts the request and returns an empty response" do
+        session.visit("http://example.com/resource.txt")
+        expect_empty_response
+      end
+    end
+
+    context "with a previously defined stub" do
+      before do
+        MiniProxy::Server.stub_request(method: "GET", url: /example.com/, response: { body: "foo" })
+        MiniProxy::Server.ignore_all_requests
+      end
+
+      after do
+        MiniProxy::Server.reset
+      end
+
+      it "intercepts the request and returns an empty response" do
+        session.visit("http://example.com/resource.txt")
+        expect_empty_response
+      end
+    end
+  end
+
+  private
+
+  def expect_empty_response
+    expect(session.html).to eq "<html><head></head><body></body></html>"
+  end
+end


### PR DESCRIPTION
Often lingering requests will hit the proxy between spec examples, causing unmocked request warning noise. Add a method to ignore all requests between spec examples.