### PR TITLE
Disable automatic requests made by firefox

### DIFF
--- a/spec/support/capybara_driver.rb
+++ b/spec/support/capybara_driver.rb
@@ -8,6 +8,14 @@ firefox_profile.proxy = Selenium::WebDriver::Proxy.new(
   ssl: "#{MiniProxy::Server.host}:#{MiniProxy::Server.port}"
 )
 
+# disabling these features ensures no automatic requests by firefox are made
+# ref: https://bugzilla.mozilla.org/show_bug.cgi?id=1410586
+firefox_profile["privacy.trackingprotection.annotate_channels"] = false
+firefox_profile["privacy.trackingprotection.enabled"] = false
+firefox_profile["privacy.trackingprotection.pbmode.enabled"] = false
+firefox_profile["plugins.flashBlock.enabled"] = false
+firefox_profile["browser.safebrowsing.blockedURIs.enable"] = false
+
 firefox_options = Selenium::WebDriver::Firefox::Options.new(profile: firefox_profile)
 firefox_options.headless!
 


### PR DESCRIPTION
Previously our build logs had a bunch of junk in them due to firefox trying to download lists of dodgy websites for safe browsing and so on. But there's no need for it to be doing that.