### PR TITLE
Create version file

### DIFF
--- a/lib/miniproxy/version.rb
+++ b/lib/miniproxy/version.rb
@@ -1,0 +1,3 @@
+module MiniProxy
+  VERSION = "0.0.1".freeze
+end

--- a/miniproxy.gemspec
+++ b/miniproxy.gemspec
@@ -1,6 +1,10 @@
-spec = Gem::Specification.new do |s|
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'miniproxy/version'
+
+Gem::Specification.new do |s|
   s.name = 'miniproxy'
-  s.version = '0.0.0'
+  s.version = MiniProxy::VERSION
   s.summary = 'Stub requests for browser tests'
   s.authors = ["x"]
 


### PR DESCRIPTION
This PR aims to add the `version.rb` file pattern, removing the hardcoded version on its gemspec. Also, bumping MiniProxy to its `0.0.1` version.

This file comes by default when creating a gem using `bundler`'s `gem` generator: `bundle gem miniproxy`.