### PR TITLE
Remove SSLCertName from fake server

### DIFF
--- a/lib/miniproxy/fake_ssl_server.rb
+++ b/lib/miniproxy/fake_ssl_server.rb
@@ -15,7 +15,6 @@ module MiniProxy
         SSLCertificate: OpenSSL::X509::Certificate.new(certificate_file("cert.pem")),
         SSLPrivateKey: OpenSSL::PKey::RSA.new(certificate_file("cert.key")),
         SSLVerifyClient: OpenSSL::SSL::VERIFY_NONE,
-        SSLCertName: [["CN", WEBrick::Utils.getservername]],
       })
 
       super(config, default)


### PR DESCRIPTION
On MacOS this was causing timeouts and was slowing everything down
for up to two minutes. It's not necessary and it's removal has sped everything up.