### PR TITLE
Add message queue for remote process, drained to stdout in main

### DIFF
--- a/lib/miniproxy/remote.rb
+++ b/lib/miniproxy/remote.rb
@@ -77,8 +77,8 @@ module MiniProxy
       else
         res.status = 200
         res.body = ""
-        STDOUT.puts "WARN: external request to #{req.host}#{req.path} not mocked"
-        STDOUT.puts %Q{Stub with: MiniProxy::Server.stub_request(method: "#{req.request_method}", url: "#{req.host}#{req.path}")}
+        queue_message "WARN: external request to #{req.host}#{req.path} not mocked"
+        queue_message %Q{Stub with: MiniProxy::Server.stub_request(method: "#{req.request_method}", url: "#{req.host}#{req.path}")}
       end
     end
 
@@ -104,6 +104,10 @@ module MiniProxy
       @stubs.clear
     end
 
+    def drain_messages
+      @messages.slice!(0, @messages.length)
+    end
+
     def started?
       current_server = DRb.current_server()
       current_server && current_server.alive?
@@ -111,8 +115,13 @@ module MiniProxy
 
     private
 
+    def queue_message(msg)
+      @messages.push msg
+    end
+
     def initialize
       @stubs = []
+      @messages = []
     end
   end
 end

--- a/lib/miniproxy/server.rb
+++ b/lib/miniproxy/server.rb
@@ -47,6 +47,8 @@ module MiniProxy
             sleep 0.01
           end
 
+          remote.drain_messages.each(&method(:puts))
+
           remote
         rescue
           retry

--- a/spec/integration/stub_requests_spec.rb
+++ b/spec/integration/stub_requests_spec.rb
@@ -23,9 +23,10 @@ RSpec.describe "miniproxy" do
     end
 
     context "not stubbed" do
-      it "intercepts the request and prints a warning to stdout", :pending do
+      it "intercepts the request and prints a warning to stdout" do
         expect {
           session.visit("http://example.com")
+          MiniProxy::Server.reset
         }.to output(/WARN/).to_stdout_from_any_process
       end
     end
@@ -48,9 +49,10 @@ RSpec.describe "miniproxy" do
     end
 
     context "not stubbed" do
-      it "intercepts the request and prints a warning to stdout", :pending do
+      it "intercepts the request and prints a warning to stdout" do
         expect {
           session.visit("http://example.com")
+          MiniProxy::Server.reset
         }.to output(/WARN/).to_stdout_from_any_process
       end
     end

--- a/spec/lib/miniproxy/remote_spec.rb
+++ b/spec/lib/miniproxy/remote_spec.rb
@@ -1,18 +1,39 @@
 require "miniproxy/remote"
 
 describe MiniProxy::Remote do
-  describe "#handler" do
-    let(:remote) { MiniProxy::Remote.new }
+  let(:remote) { MiniProxy::Remote.new }
 
+  describe "#handler" do
     context "when the request has not been mocked" do
       let(:req) { double(:request, request_method: 'GET', host: 'example.com', path: '/') }
       let(:res) { WEBrick::HTTPResponse.new(WEBrick::Config::HTTP) }
 
-      it "outputs an error message" do
-        expect(STDOUT).to receive(:puts).with("WARN: external request to example.com/ not mocked")
-        expect(STDOUT).to receive(:puts).with(%q(Stub with: MiniProxy::Server.stub_request(method: "GET", url: "example.com/")))
-
+      it "queues error messages" do
         remote.handler(req, res)
+
+        expect(remote.drain_messages).to eql [
+          "WARN: external request to example.com/ not mocked",
+          %q(Stub with: MiniProxy::Server.stub_request(method: "GET", url: "example.com/"))
+        ]
+      end
+    end
+  end
+
+  describe "#drain_messages" do
+    context "queued messages" do
+      before do
+        remote.instance_variable_set(:@messages, ["hello", "world"])
+      end
+
+      it "drains queued messages" do
+        expect(remote.drain_messages).to eql ["hello", "world"]
+        expect(remote.drain_messages).to be_empty
+      end
+    end
+
+    context "no queued messages" do
+      it "returns an empty array" do
+        expect(remote.drain_messages).to eql []
       end
     end
   end


### PR DESCRIPTION
This allows us to capture the output with rspec more easily, making our integration tests looking for stdout messages actually work as expected.

The messages are queued on the remote process, to be drained by the client (main process) whenever the client connects to the remote object.