### PR TITLE
Add author and license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 The Conversation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/miniproxy.gemspec
+++ b/miniproxy.gemspec
@@ -5,8 +5,12 @@ require 'miniproxy/version'
 Gem::Specification.new do |s|
   s.name = 'miniproxy'
   s.version = MiniProxy::VERSION
-  s.summary = 'Stub requests for browser tests'
-  s.authors = ["x"]
+  s.authors = ['The Conversation Dev Team']
+
+  s.summary = 'Easily stub external requests for your browser tests.'
+  s.description = 'A tool which allows you to easily stub requests to external sites for your browser tests.'
+  s.homepage = 'https://github.com/conversation/miniproxy'
+  s.license = 'MIT'
 
   s.files = `git ls-files -- lib/*`.split("\n")
 


### PR DESCRIPTION
This PR aims to add a license to MiniProxy and The Conversation dev team as author to `MiniProxy`.