### PR TITLE
Add specs for ProxyServer and FakeSSLServer

### DIFF
--- a/spec/lib/miniproxy/fake_ssl_server_spec.rb
+++ b/spec/lib/miniproxy/fake_ssl_server_spec.rb
@@ -1,1 +1,40 @@
 require "miniproxy/fake_ssl_server"
+
+RSpec.describe MiniProxy::FakeSSLServer do
+  describe "#service" do
+    let(:fake_ssl_server) {
+      MiniProxy::FakeSSLServer.new(
+        Port: (12345..32768).to_a.sample,
+        MockHandlerCallback: handler
+      )
+    }
+    let(:res) { MiniProxy::Stub::Response.new(headers: [], body: "") }
+    let(:handler) { double(:handler) }
+
+    describe "requests to localhost" do
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://localhost/", host: "localhost", path: "/") }
+      let(:servlet) { double(:servlet, get_instance: servlet_instance) }
+      let(:servlet_instance) { double(:servlet_instance) }
+
+      before do
+        allow(req).to receive(:script_name=)
+        allow(req).to receive(:path_info=)
+      end
+
+      it "performs the request" do
+        expect(fake_ssl_server).to receive(:search_servlet).and_return(servlet)
+        expect(servlet_instance).to receive(:service).with(req, res)
+        fake_ssl_server.service(req, res)
+      end
+    end
+
+    describe "requests to remote hosts" do
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://example.com/", host: "example.com") }
+
+      it "calls the mock handler" do
+        expect(handler).to receive(:call).with(req, res)
+        fake_ssl_server.service(req, res)
+      end
+    end
+  end
+end

--- a/spec/lib/miniproxy/proxy_server_spec.rb
+++ b/spec/lib/miniproxy/proxy_server_spec.rb
@@ -1,7 +1,49 @@
 require "miniproxy/proxy_server"
 
 RSpec.describe MiniProxy::ProxyServer do
-  it "works" do
-    expect("something").to eq "something"
+  describe "#service" do
+    let(:proxy_server) {
+      MiniProxy::ProxyServer.new(
+        Port: (12345..32768).to_a.sample,
+        FakeServerPort: 33333,
+        MockHandlerCallback: handler
+      )
+    }
+    let(:res) { MiniProxy::Stub::Response.new(headers: [], body: "") }
+    let(:handler) { double(:handler) }
+
+    describe "requests to localhost" do
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "GET", unparsed_uri: "http://localhost/", host: "localhost") }
+
+      it "performs the request" do
+        expect(proxy_server).to receive(:proxy_service).with(req, res)
+        proxy_server.service(req, res)
+      end
+    end
+
+    describe "SSL requests" do
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://example.com/", host: "example.com") }
+      let(:req_unparsed_uri) { req.instance_variable_get(:@unparsed_uri) }
+
+      it "rewrites the request to point to our fake SSL server" do
+        allow(proxy_server).to receive(:do_CONNECT)
+        proxy_server.service(req, res)
+        expect(req_unparsed_uri).to eq "localhost:33333"
+      end
+
+      it "performs the request" do
+        expect(proxy_server).to receive(:do_CONNECT).with(req, res)
+        proxy_server.service(req, res)
+      end
+    end
+
+    describe "non-SSL requests to remote hosts" do
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "GET", unparsed_uri: "http://example.com/", host: "example.com") }
+
+      it "calls the mock handler" do
+        expect(handler).to receive(:call).with(req, res)
+        proxy_server.service(req, res)
+      end
+    end
   end
 end


### PR DESCRIPTION
Add specs for `ProxyServer` and `FakeSSLServer`, focusing on the `#service` method where most of the interest is.

Because we're unit testing with stubs, the specs for `FakeSSLServer` in particular are quite coupled to the internals of WEBrick. Definitely open to suggestions of alternate approaches.