### PR TITLE
Allow external requests feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ In your specs, to stub a request:
 
 To allow unstubbed requests to hit external servers:
 
-    MiniProxy::Server.set_config :allow_external_requests, true
+    MiniProxy::Server.allow_external_requests = true
 
 The default behaviour is to block the request, display a warning and return an empty 200 response.
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ In your specs, to stub a request:
       body: "hello",
     })
 
+To allow unstubbed requests to hit external servers:
+
+    MiniProxy::Server.set_config :allow_external_requests, true
+
+The default behaviour is to block the request, display a warning and return an empty 200 response.
+
 
 ## Developing
 

--- a/lib/miniproxy/config.rb
+++ b/lib/miniproxy/config.rb
@@ -1,0 +1,6 @@
+module MiniProxy
+  # MiniProxy-level configuration options
+  #
+  class Config < Struct.new(:allow_external_requests)
+  end
+end

--- a/lib/miniproxy/fake_ssl_server.rb
+++ b/lib/miniproxy/fake_ssl_server.rb
@@ -29,7 +29,7 @@ module MiniProxy
         handled = self.config[:MockHandlerCallback].call(req, res)
 
         # If we have no stub and we're allowing external requests, hit the internet
-        super(req, res) if !handled && @miniproxy_config.call.allow_external_requests
+        super(req, res) if !handled && @miniproxy_config.allow_external_requests
       end
     end
 

--- a/lib/miniproxy/fake_ssl_server.rb
+++ b/lib/miniproxy/fake_ssl_server.rb
@@ -8,6 +8,8 @@ module MiniProxy
     ALLOWED_HOSTS = ["127.0.0.1", "localhost"].freeze
 
     def initialize(config = {}, default = WEBrick::Config::HTTP)
+      @miniproxy_config = config[:MiniproxyConfig]
+
       config = config.merge({
         Logger: WEBrick::Log.new(nil, 0), # silence logging
         AccessLog: [], # silence logging
@@ -24,7 +26,10 @@ module MiniProxy
       if ALLOWED_HOSTS.include?(req.host)
         super(req, res)
       else
-        self.config[:MockHandlerCallback].call(req, res)
+        handled = self.config[:MockHandlerCallback].call(req, res)
+
+        # If we have no stub and we're allowing external requests, hit the internet
+        super(req, res) if !handled && @miniproxy_config.call.allow_external_requests
       end
     end
 

--- a/lib/miniproxy/proxy_server.rb
+++ b/lib/miniproxy/proxy_server.rb
@@ -9,6 +9,8 @@ module MiniProxy
     attr_accessor :requests
 
     def initialize(config = {}, default = WEBrick::Config::HTTP)
+      @miniproxy_config = config[:MiniproxyConfig]
+
       config = config.merge({
         Logger: WEBrick::Log.new(nil, 0), # silence logging
         AccessLog: [], # silence logging
@@ -46,7 +48,10 @@ module MiniProxy
       else
         # Otherwise, call our handler to respond with an appropriate
         # mock for the request.
-        self.config[:MockHandlerCallback].call(req, res)
+        handled = self.config[:MockHandlerCallback].call(req, res)
+
+        # If we have no stub and we're allowing external requests, hit the internet
+        super(req, res) if !handled && @miniproxy_config.call.allow_external_requests
       end
     end
   end

--- a/lib/miniproxy/proxy_server.rb
+++ b/lib/miniproxy/proxy_server.rb
@@ -51,7 +51,7 @@ module MiniProxy
         handled = self.config[:MockHandlerCallback].call(req, res)
 
         # If we have no stub and we're allowing external requests, hit the internet
-        super(req, res) if !handled && @miniproxy_config.call.allow_external_requests
+        super(req, res) if !handled && @miniproxy_config.allow_external_requests
       end
     end
   end

--- a/lib/miniproxy/proxy_server.rb
+++ b/lib/miniproxy/proxy_server.rb
@@ -38,17 +38,15 @@ module MiniProxy
     def service(req, res)
       if ALLOWED_HOSTS.include?(req.host)
         super(req, res)
+      elsif req.request_method == "CONNECT"
+        # If something is trying to initiate an SSL connection, rewrite
+        # the URI to point to our fake server.
+        req.instance_variable_set(:@unparsed_uri, "localhost:#{self.config[:FakeServerPort]}")
+        super(req, res)
       else
-        if req.request_method == "CONNECT"
-          # If something is trying to initiate an SSL connection, rewrite
-          # the URI to point to our fake server.
-          req.instance_variable_set(:@unparsed_uri, "localhost:#{self.config[:FakeServerPort]}")
-          super(req, res)
-        else
-          # Otherwise, call our handler to respond with an appropriate
-          # mock for the request.
-          self.config[:MockHandlerCallback].call(req, res)
-        end
+        # Otherwise, call our handler to respond with an appropriate
+        # mock for the request.
+        self.config[:MockHandlerCallback].call(req, res)
       end
     end
   end

--- a/lib/miniproxy/remote.rb
+++ b/lib/miniproxy/remote.rb
@@ -39,7 +39,7 @@ module MiniProxy
             fake_server_port = SERVER_DYNAMIC_PORT_RANGE.sample
             fake_server = FakeSSLServer.new(
               Port: fake_server_port,
-              MiniproxyConfig: remote.method(:config),
+              MiniproxyConfig: remote.config,
               MockHandlerCallback: remote.method(:handler),
             )
             Thread.new { fake_server.start }
@@ -52,7 +52,7 @@ module MiniProxy
             proxy = MiniProxy::ProxyServer.new(
               Port: remote.port,
               FakeServerPort: fake_server_port,
-              MiniproxyConfig: remote.method(:config),
+              MiniproxyConfig: remote.config,
               MockHandlerCallback: remote.method(:handler),
             )
             Thread.new { proxy.start }
@@ -77,6 +77,10 @@ module MiniProxy
 
     def set_config(k, v)
       @miniproxy_config[k] = v
+    end
+
+    def config
+      @miniproxy_config
     end
 
     def handler(req, res)
@@ -133,10 +137,6 @@ module MiniProxy
 
     def queue_message(msg)
       @messages.push msg
-    end
-
-    def config
-      @miniproxy_config
     end
 
     def initialize

--- a/lib/miniproxy/remote.rb
+++ b/lib/miniproxy/remote.rb
@@ -1,3 +1,4 @@
+require "miniproxy/config"
 require "miniproxy/stub/request"
 require "miniproxy/stub/response"
 require "miniproxy/proxy_server"
@@ -68,6 +69,14 @@ module MiniProxy
       @unix_socket_uri
     end
 
+    def get_config(k)
+      @miniproxy_config[k]
+    end
+
+    def set_config(k, v)
+      @miniproxy_config[k] = v
+    end
+
     def handler(req, res)
       if (request = @stubs.detect { |mock_request| mock_request.match?(req) })
         response = request.response
@@ -122,6 +131,9 @@ module MiniProxy
     def initialize
       @stubs = []
       @messages = []
+      @miniproxy_config = Config.new.tap do |c|
+        c.allow_external_requests = false
+      end
     end
   end
 end

--- a/lib/miniproxy/server.rb
+++ b/lib/miniproxy/server.rb
@@ -10,6 +10,14 @@ module MiniProxy
   class Server
     DRB_SERVICE_TIMEOUT = 5
 
+    def self.get_config(k)
+      remote.get_config(k)
+    end
+
+    def self.set_config(k, v)
+      remote.set_config(k, v)
+    end
+
     def self.reset
       remote.clear
     end

--- a/lib/miniproxy/server.rb
+++ b/lib/miniproxy/server.rb
@@ -10,12 +10,8 @@ module MiniProxy
   class Server
     DRB_SERVICE_TIMEOUT = 5
 
-    def self.get_config(k)
-      remote.get_config(k)
-    end
-
-    def self.set_config(k, v)
-      remote.set_config(k, v)
+    def self.allow_external_requests=(is_allowed)
+      remote.set_config(:allow_external_requests, is_allowed)
     end
 
     def self.reset

--- a/spec/integration/allow_external_requests_spec.rb
+++ b/spec/integration/allow_external_requests_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "miniproxy" do
   let(:session) { Capybara::Session.new(:firefox) }
 
   describe "allowing external requests" do
-    before { MiniProxy::Server.set_config :allow_external_requests, true }
-    after { MiniProxy::Server.set_config :allow_external_requests, false }
+    before { MiniProxy::Server.allow_external_requests = true }
+    after { MiniProxy::Server.allow_external_requests = false }
 
     it "hits the internet" do
       session.visit("http://example.com")
@@ -32,12 +32,12 @@ RSpec.describe "miniproxy" do
 
     describe "alternating configuration on the fly" do
       it "works as expected when toggling allow_external_requests" do
-        expect(MiniProxy::Server.get_config(:allow_external_requests)).to be true
+        MiniProxy::Server.allow_external_requests = true
 
         session.visit("http://example.com")
         expect(session).to have_content "Example Domain"
 
-        MiniProxy::Server.set_config :allow_external_requests, false
+        MiniProxy::Server.allow_external_requests = false
 
         expect {
           session.visit("http://foo.com")

--- a/spec/integration/allow_external_requests_spec.rb
+++ b/spec/integration/allow_external_requests_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe "miniproxy" do
     before { MiniProxy::Server.set_config :allow_external_requests, true }
     after { MiniProxy::Server.set_config :allow_external_requests, false }
 
-
     it "hits the internet" do
       session.visit("http://example.com")
       expect(session).to have_content "Example Domain"
@@ -28,6 +27,22 @@ RSpec.describe "miniproxy" do
         session.visit("http://example.com")
         expect(session).to have_content "foo"
         expect(session).not_to have_content "Example Domain"
+      end
+    end
+
+    describe "alternating configuration on the fly" do
+      it "works as expected when toggling allow_external_requests" do
+        expect(MiniProxy::Server.get_config(:allow_external_requests)).to be true
+
+        session.visit("http://example.com")
+        expect(session).to have_content "Example Domain"
+
+        MiniProxy::Server.set_config :allow_external_requests, false
+
+        expect {
+          session.visit("http://foo.com")
+          MiniProxy::Server.reset
+        }.to output(/WARN/).to_stdout_from_any_process
       end
     end
   end

--- a/spec/integration/allow_external_requests_spec.rb
+++ b/spec/integration/allow_external_requests_spec.rb
@@ -1,0 +1,34 @@
+require "capybara"
+require "miniproxy"
+require "support/capybara_driver"
+
+RSpec.describe "miniproxy" do
+  let(:session) { Capybara::Session.new(:firefox) }
+
+  describe "allowing external requests" do
+    before { MiniProxy::Server.set_config :allow_external_requests, true }
+    after { MiniProxy::Server.set_config :allow_external_requests, false }
+
+
+    it "hits the internet" do
+      session.visit("http://example.com")
+      expect(session).to have_content "Example Domain"
+    end
+
+    context "when a stub is set" do
+      before do
+        MiniProxy::Server.stub_request(method: "GET", url: /example.com/, response: { body: "foo" })
+      end
+
+      after do
+        MiniProxy::Server.reset
+      end
+
+      it "uses the stub rather than hitting the internet" do
+        session.visit("http://example.com")
+        expect(session).to have_content "foo"
+        expect(session).not_to have_content "Example Domain"
+      end
+    end
+  end
+end


### PR DESCRIPTION
We'd like to be able to use MiniProxy for jobs and donations, but the tests of both of these apps need to be able to hit the internet, a feature MiniProxy currently doesn't provide. To fix this, add a configuration option `allow_external_requests` (off by default).

I was somewhat limited in the configuration API since any changes to config must be made via a method call on `Remote`. Retrieving and mutating a `Config` object won't work since only the initial retrieval is performed via DRb - the mutations are not and so won't have any effect. Within these constraints I'm still curious for feedback on ways to improve this interface if you can see any.

TODO:

- [x] Update README