### PR TITLE
Mutable allowed hosts

### DIFF
--- a/lib/miniproxy.rb
+++ b/lib/miniproxy.rb
@@ -18,7 +18,11 @@ module MiniProxy
   end
 
   def self.host
-    "127.0.0.1"
+    @host || "127.0.0.1"
+  end
+
+  def self.host=(host)
+    @host = host
   end
 
   def self.ignore_all_requests
@@ -36,7 +40,7 @@ module MiniProxy
   private_class_method def self.remote
     Timeout.timeout(DRB_SERVICE_TIMEOUT) do
       begin
-        remote = DRbObject.new(nil, Remote.server)
+        remote = DRbObject.new(nil, Remote.server(self.host))
 
         until remote.started?
           sleep 0.01

--- a/lib/miniproxy/fake_ssl_server.rb
+++ b/lib/miniproxy/fake_ssl_server.rb
@@ -5,9 +5,9 @@ module MiniProxy
   # MiniProxy fake SSL enabled server, which receives relayed requests from the ProxyServer
   #
   class FakeSSLServer < WEBrick::HTTPServer
-    ALLOWED_HOSTS = ["127.0.0.1", "localhost"].freeze
-
     def initialize(config = {}, default = WEBrick::Config::HTTP)
+      @allowed_hosts = ["127.0.0.1", "localhost"]
+
       config = config.merge({
         Logger: WEBrick::Log.new(nil, 0), # silence logging
         AccessLog: [], # silence logging
@@ -21,7 +21,7 @@ module MiniProxy
     end
 
     def service(req, res)
-      if ALLOWED_HOSTS.include?(req.host)
+      if @allowed_hosts.include?(req.host)
         super(req, res)
       else
         self.config[:MockHandlerCallback].call(req, res)

--- a/lib/miniproxy/fake_ssl_server.rb
+++ b/lib/miniproxy/fake_ssl_server.rb
@@ -6,7 +6,7 @@ module MiniProxy
   #
   class FakeSSLServer < WEBrick::HTTPServer
     def initialize(config = {}, default = WEBrick::Config::HTTP)
-      @allowed_hosts = ["127.0.0.1", "localhost"]
+      @allowed_hosts = ["127.0.0.1", "localhost", config[:MiniProxyHost]].compact
 
       config = config.merge({
         Logger: WEBrick::Log.new(nil, 0), # silence logging

--- a/lib/miniproxy/proxy_server.rb
+++ b/lib/miniproxy/proxy_server.rb
@@ -4,11 +4,11 @@ module MiniProxy
   # MiniProxy server, which boots a WEBrick proxy server
   #
   class ProxyServer < WEBrick::HTTPProxyServer
-    ALLOWED_HOSTS = ["127.0.0.1", "localhost"].freeze
-
     attr_accessor :requests
 
     def initialize(config = {}, default = WEBrick::Config::HTTP)
+      @allowed_hosts = ["127.0.0.1", "localhost"]
+
       config = config.merge({
         Logger: WEBrick::Log.new(nil, 0), # silence logging
         AccessLog: [], # silence logging
@@ -36,7 +36,7 @@ module MiniProxy
     end
 
     def service(req, res)
-      if ALLOWED_HOSTS.include?(req.host)
+      if @allowed_hosts.include?(req.host)
         super(req, res)
       else
         if req.request_method == "CONNECT"

--- a/lib/miniproxy/proxy_server.rb
+++ b/lib/miniproxy/proxy_server.rb
@@ -7,7 +7,7 @@ module MiniProxy
     attr_accessor :requests
 
     def initialize(config = {}, default = WEBrick::Config::HTTP)
-      @allowed_hosts = ["127.0.0.1", "localhost"]
+      @allowed_hosts = ["127.0.0.1", "localhost", config[:MiniProxyHost]].compact
 
       config = config.merge({
         Logger: WEBrick::Log.new(nil, 0), # silence logging

--- a/lib/miniproxy/remote.rb
+++ b/lib/miniproxy/remote.rb
@@ -20,7 +20,7 @@ module MiniProxy
       false
     end
 
-    def self.server
+    def self.server(host = "127.0.0.1")
       @unix_socket_uri ||= begin
         tempfile = Tempfile.new("mini_proxy")
         socket_path = tempfile.path
@@ -37,6 +37,7 @@ module MiniProxy
           begin
             fake_server_port = SERVER_DYNAMIC_PORT_RANGE.sample
             fake_server = FakeSSLServer.new(
+              MiniProxyHost: host,
               Port: fake_server_port,
               MockHandlerCallback: remote.method(:handler),
             )
@@ -48,6 +49,7 @@ module MiniProxy
           begin
             remote.port = ENV["MINI_PROXY_PORT"] || SERVER_DYNAMIC_PORT_RANGE.sample
             proxy = MiniProxy::ProxyServer.new(
+              MiniProxyHost: host,
               Port: remote.port,
               FakeServerPort: fake_server_port,
               MockHandlerCallback: remote.method(:handler),

--- a/spec/lib/miniproxy/fake_ssl_server_spec.rb
+++ b/spec/lib/miniproxy/fake_ssl_server_spec.rb
@@ -2,8 +2,10 @@ require "miniproxy/fake_ssl_server"
 
 RSpec.describe MiniProxy::FakeSSLServer do
   describe "#service" do
+    let(:host) { "123.45.65.43" }
     let(:fake_ssl_server) {
       MiniProxy::FakeSSLServer.new(
+        MiniProxyHost: host,
         Port: (12345..32768).to_a.sample,
         MockHandlerCallback: handler,
       )
@@ -12,7 +14,7 @@ RSpec.describe MiniProxy::FakeSSLServer do
     let(:handler) { double(:handler) }
 
     describe "requests to localhost" do
-      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://localhost/", host: "localhost", path: "/") }
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://#{host}/", host: host, path: "/") }
       let(:servlet) { double(:servlet, get_instance: servlet_instance) }
       let(:servlet_instance) { double(:servlet_instance) }
 

--- a/spec/lib/miniproxy/proxy_server_spec.rb
+++ b/spec/lib/miniproxy/proxy_server_spec.rb
@@ -2,8 +2,10 @@ require "miniproxy/proxy_server"
 
 RSpec.describe MiniProxy::ProxyServer do
   describe "#service" do
+    let(:host) { "123.45.65.43" }
     let(:proxy_server) {
       MiniProxy::ProxyServer.new(
+        MiniProxyHost: host,
         Port: (12345..32768).to_a.sample,
         FakeServerPort: 33333,
         MockHandlerCallback: handler,
@@ -14,7 +16,7 @@ RSpec.describe MiniProxy::ProxyServer do
     let(:handler) { double(:handler) }
 
     describe "requests to localhost" do
-      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "GET", unparsed_uri: "http://localhost/", host: "localhost") }
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "GET", unparsed_uri: "http://#{host}/", host: host) }
 
       it "performs the request" do
         expect(proxy_server).to receive(:proxy_service).with(req, res)


### PR DESCRIPTION
When our specs for jobs run in docker, they run on a specific IP address, not on 127.0.0.1. Therefore, we need to allow MiniProxy to connect to this host. Add support for setting a custom host for MiniProxy, and allow requests to that host.