### PR TITLE
Allow websocket connections to pass through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.0
+
+- Feature: Support Websocket connection upgrade passthrough
+
 ## 0.3.0
 
 - Feature: Allow configurable MiniProxy host (#25)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0
 
-- Feature: Support Websocket connection upgrade passthrough
+- Feature: Support Websocket connection upgrade passthrough (#28)
 
 ## 0.3.0
 

--- a/lib/miniproxy/proxy_server.rb
+++ b/lib/miniproxy/proxy_server.rb
@@ -40,9 +40,14 @@ module MiniProxy
         super(req, res)
       else
         if req.request_method == "CONNECT"
+          is_ssl = req.unparsed_uri.include?(":443")
+
           # If something is trying to initiate an SSL connection, rewrite
-          # the URI to point to our fake server.
-          req.instance_variable_set(:@unparsed_uri, "localhost:#{self.config[:FakeServerPort]}")
+          # the URI to point to our fake server so we can stub SSL requests.
+          if is_ssl
+            req.instance_variable_set(:@unparsed_uri, "localhost:#{self.config[:FakeServerPort]}")
+          end
+
           super(req, res)
         else
           # Otherwise, call our handler to respond with an appropriate

--- a/lib/miniproxy/version.rb
+++ b/lib/miniproxy/version.rb
@@ -1,3 +1,3 @@
 module MiniProxy
-  VERSION = "0.3.0".freeze
+  VERSION = "0.4.0".freeze
 end

--- a/spec/lib/miniproxy/proxy_server_spec.rb
+++ b/spec/lib/miniproxy/proxy_server_spec.rb
@@ -24,14 +24,30 @@ RSpec.describe MiniProxy::ProxyServer do
       end
     end
 
-    describe "SSL requests" do
-      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://example.com/", host: "example.com") }
+    describe "SSL CONNECT requests" do
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://example.com:443", host: "example.com") }
       let(:req_unparsed_uri) { req.instance_variable_get(:@unparsed_uri) }
 
       it "rewrites the request to point to our fake SSL server" do
         allow(proxy_server).to receive(:do_CONNECT)
         proxy_server.service(req, res)
         expect(req_unparsed_uri).to eq "localhost:33333"
+      end
+
+      it "performs the request" do
+        expect(proxy_server).to receive(:do_CONNECT).with(req, res)
+        proxy_server.service(req, res)
+      end
+    end
+
+    describe "non-SSL CONNECT requests" do
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "example.com:1234", host: "example.com") }
+      let(:req_unparsed_uri) { req.instance_variable_get(:@unparsed_uri) }
+
+      it "does not rewrite the request to point to our fake SSL server" do
+        allow(proxy_server).to receive(:do_CONNECT)
+        proxy_server.service(req, res)
+        expect(req_unparsed_uri).to eq nil
       end
 
       it "performs the request" do


### PR DESCRIPTION
This allows for things like websocket connections from clients to be negotiated successfully through the proxy.

For a great explantion of how clients negotiate websocket connections through proxy servers, take a look at this:

https://www.infoq.com/articles/Web-Sockets-Proxy-Servers

![websockets2](https://user-images.githubusercontent.com/2295892/45801668-e03f7800-bcf7-11e8-925c-d7b3336167de.png)
