### PR TITLE
Test MiniProxy against Ruby 2.4 until 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ branches:
     - master
 language: ruby
 rvm:
+  - 2.7
+  - 2.6
   - 2.5
+  - 2.4
 addons:
   firefox: "65.0"
 before_install:


### PR DESCRIPTION
This PR aims to broad MiniProxy's Ruby versions on Travis CI, making sure it works on Ruby versions from `2.4` until `2.7`.