### PR TITLE
Update Travis Firefox version to 65.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: ruby
 rvm:
   - 2.5
 addons:
-  firefox: "60.0"
+  firefox: "65.0"
 before_install:
   - wget https://github.com/mozilla/geckodriver/releases/download/v0.21.0/geckodriver-v0.21.0-linux64.tar.gz
   - mkdir geckodriver


### PR DESCRIPTION
This PR updates MiniProxy's Firefox version, testing it against its latest version at the time of this writing (v65.0).