### PR TITLE
Support configurable allowed requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 Gemfile.lock
+.bundle/config
+vendor/bundle

--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ MiniProxy.host = "95.124.236.242"
 
 With this configuration, MiniProxy will allow all requests coming from the configured host.
 
+You also can permit specific requests to pass through the proxy:
+
+```ruby
+MiniProxy.allow_request(method: "GET", url: /example.com/)
+```
+
+This implicitly allows CONNECT requests for 'example.com' to permit HTTPS.
+
 ## Developing
 
 Pull requests are welcome, we try our best to stick with [semver](https://semver.org/), avoid breaking changes to the API whenever possible.

--- a/lib/miniproxy.rb
+++ b/lib/miniproxy.rb
@@ -37,6 +37,10 @@ module MiniProxy
     remote.stub_request(method: method, url: url, response: response)
   end
 
+  def self.allow_request(method:, url:)
+    remote.allow_request(method: method, url: url)
+  end
+
   private_class_method def self.remote
     Timeout.timeout(DRB_SERVICE_TIMEOUT) do
       begin

--- a/lib/miniproxy/fake_ssl_server.rb
+++ b/lib/miniproxy/fake_ssl_server.rb
@@ -6,8 +6,6 @@ module MiniProxy
   #
   class FakeSSLServer < WEBrick::HTTPServer
     def initialize(config = {}, default = WEBrick::Config::HTTP)
-      @allowed_hosts = ["127.0.0.1", "localhost", config[:MiniProxyHost]].compact
-
       config = config.merge({
         Logger: WEBrick::Log.new(nil, 0), # silence logging
         AccessLog: [], # silence logging
@@ -21,7 +19,7 @@ module MiniProxy
     end
 
     def service(req, res)
-      if @allowed_hosts.include?(req.host)
+      if self.config[:AllowedRequestCheck].call(req)
         super(req, res)
       else
         self.config[:MockHandlerCallback].call(req, res)

--- a/lib/miniproxy/proxy_server.rb
+++ b/lib/miniproxy/proxy_server.rb
@@ -7,8 +7,6 @@ module MiniProxy
     attr_accessor :requests
 
     def initialize(config = {}, default = WEBrick::Config::HTTP)
-      @allowed_hosts = ["127.0.0.1", "localhost", config[:MiniProxyHost]].compact
-
       config = config.merge({
         Logger: WEBrick::Log.new(nil, 0), # silence logging
         AccessLog: [], # silence logging
@@ -36,7 +34,7 @@ module MiniProxy
     end
 
     def service(req, res)
-      if @allowed_hosts.include?(req.host)
+      if self.config[:AllowedRequestCheck].call(req)
         super(req, res)
       else
         if req.request_method == "CONNECT"

--- a/lib/miniproxy/stub/request.rb
+++ b/lib/miniproxy/stub/request.rb
@@ -16,8 +16,13 @@ module MiniProxy
 
       # @param [WEBrick::HTTPRequest] http_request
       def match?(http_request)
-        request_uri = http_request.host + http_request.path
-        http_request.request_method == @method && request_uri.match?(@url)
+        if http_request.request_method == "CONNECT"
+          host = http_request.unparsed_uri.split(":").first
+          @url.match?(host)
+        else
+          request_uri = http_request.host + http_request.path
+          http_request.request_method == @method && request_uri.match?(@url)
+        end
       end
     end
   end

--- a/spec/integration/stub_requests_spec.rb
+++ b/spec/integration/stub_requests_spec.rb
@@ -30,6 +30,17 @@ RSpec.describe "miniproxy" do
         }.to output(/WARN/).to_stdout_from_any_process
       end
     end
+
+    context "allowed" do
+      it "proxies the request" do
+        MiniProxy.allow_request(method: "GET", url: /example.com/)
+
+        session.visit("http://example.com")
+        MiniProxy.reset
+
+        expect(session).to have_content("Example Domain")
+      end
+    end
   end
 
   describe "https request" do
@@ -51,9 +62,20 @@ RSpec.describe "miniproxy" do
     context "not stubbed" do
       it "intercepts the request and prints a warning to stdout" do
         expect {
-          session.visit("http://example.com")
+          session.visit("https://example.com")
           MiniProxy.reset
         }.to output(/WARN/).to_stdout_from_any_process
+      end
+    end
+
+    context "allowed" do
+      it "proxies the request" do
+        MiniProxy.allow_request(method: "GET", url: /example.com/)
+
+        session.visit("https://example.com/")
+        MiniProxy.reset
+
+        expect(session).to have_content("Example Domain")
       end
     end
   end

--- a/spec/lib/miniproxy/fake_ssl_server_spec.rb
+++ b/spec/lib/miniproxy/fake_ssl_server_spec.rb
@@ -2,10 +2,10 @@ require "miniproxy/fake_ssl_server"
 
 RSpec.describe MiniProxy::FakeSSLServer do
   describe "#service" do
-    let(:host) { "123.45.65.43" }
+    let(:allowed_request_check) { ->(req) { false } }
     let(:fake_ssl_server) {
       MiniProxy::FakeSSLServer.new(
-        MiniProxyHost: host,
+        AllowedRequestCheck: allowed_request_check,
         Port: (12345..32768).to_a.sample,
         MockHandlerCallback: handler,
       )
@@ -13,8 +13,9 @@ RSpec.describe MiniProxy::FakeSSLServer do
     let(:res) { MiniProxy::Stub::Response.new(headers: [], body: "") }
     let(:handler) { double(:handler) }
 
-    describe "requests to localhost" do
-      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://#{host}/", host: host, path: "/") }
+    describe "when the request is allowed" do
+      let(:allowed_request_check) { ->(req) { true } }
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://localhost/", host: "localhost", path: "/") }
       let(:servlet) { double(:servlet, get_instance: servlet_instance) }
       let(:servlet_instance) { double(:servlet_instance) }
 

--- a/spec/lib/miniproxy/proxy_server_spec.rb
+++ b/spec/lib/miniproxy/proxy_server_spec.rb
@@ -2,10 +2,10 @@ require "miniproxy/proxy_server"
 
 RSpec.describe MiniProxy::ProxyServer do
   describe "#service" do
-    let(:host) { "123.45.65.43" }
+    let(:allowed_request_check) { ->(req) { false } }
     let(:proxy_server) {
       MiniProxy::ProxyServer.new(
-        MiniProxyHost: host,
+        AllowedRequestCheck: allowed_request_check,
         Port: (12345..32768).to_a.sample,
         FakeServerPort: 33333,
         MockHandlerCallback: handler,
@@ -15,8 +15,9 @@ RSpec.describe MiniProxy::ProxyServer do
     let(:res) { MiniProxy::Stub::Response.new(headers: [], body: "") }
     let(:handler) { double(:handler) }
 
-    describe "requests to localhost" do
-      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "GET", unparsed_uri: "http://#{host}/", host: host) }
+    context "when the request is allowed" do
+      let(:allowed_request_check) { ->(req) { true } }
+      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "GET", unparsed_uri: "http://localhost/", host: "localhost") }
 
       it "performs the request" do
         expect(proxy_server).to receive(:proxy_service).with(req, res)
@@ -24,44 +25,46 @@ RSpec.describe MiniProxy::ProxyServer do
       end
     end
 
-    describe "SSL CONNECT requests" do
-      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://example.com:443", host: "example.com") }
-      let(:req_unparsed_uri) { req.instance_variable_get(:@unparsed_uri) }
+    context "when the request is not allowed" do
+      describe "SSL CONNECT requests" do
+        let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "https://example.com:443", host: "example.com") }
+        let(:req_unparsed_uri) { req.instance_variable_get(:@unparsed_uri) }
 
-      it "rewrites the request to point to our fake SSL server" do
-        allow(proxy_server).to receive(:do_CONNECT)
-        proxy_server.service(req, res)
-        expect(req_unparsed_uri).to eq "localhost:33333"
+        it "rewrites the request to point to our fake SSL server" do
+          allow(proxy_server).to receive(:do_CONNECT)
+          proxy_server.service(req, res)
+          expect(req_unparsed_uri).to eq "localhost:33333"
+        end
+
+        it "performs the request" do
+          expect(proxy_server).to receive(:do_CONNECT).with(req, res)
+          proxy_server.service(req, res)
+        end
       end
 
-      it "performs the request" do
-        expect(proxy_server).to receive(:do_CONNECT).with(req, res)
-        proxy_server.service(req, res)
+      describe "non-SSL CONNECT requests" do
+        let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "example.com:1234", host: "example.com") }
+        let(:req_unparsed_uri) { req.instance_variable_get(:@unparsed_uri) }
+
+        it "does not rewrite the request to point to our fake SSL server" do
+          allow(proxy_server).to receive(:do_CONNECT)
+          proxy_server.service(req, res)
+          expect(req_unparsed_uri).to eq nil
+        end
+
+        it "performs the request" do
+          expect(proxy_server).to receive(:do_CONNECT).with(req, res)
+          proxy_server.service(req, res)
+        end
       end
-    end
 
-    describe "non-SSL CONNECT requests" do
-      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "example.com:1234", host: "example.com") }
-      let(:req_unparsed_uri) { req.instance_variable_get(:@unparsed_uri) }
+      describe "non-SSL requests to remote hosts" do
+        let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "GET", unparsed_uri: "http://example.com/", host: "example.com") }
 
-      it "does not rewrite the request to point to our fake SSL server" do
-        allow(proxy_server).to receive(:do_CONNECT)
-        proxy_server.service(req, res)
-        expect(req_unparsed_uri).to eq nil
-      end
-
-      it "performs the request" do
-        expect(proxy_server).to receive(:do_CONNECT).with(req, res)
-        proxy_server.service(req, res)
-      end
-    end
-
-    describe "non-SSL requests to remote hosts" do
-      let(:req) { instance_double(WEBrick::HTTPRequest, request_method: "GET", unparsed_uri: "http://example.com/", host: "example.com") }
-
-      it "calls the mock handler" do
-        expect(handler).to receive(:call).with(req, res)
-        proxy_server.service(req, res)
+        it "calls the mock handler" do
+          expect(handler).to receive(:call).with(req, res)
+          proxy_server.service(req, res)
+        end
       end
     end
   end

--- a/spec/lib/miniproxy/remote_spec.rb
+++ b/spec/lib/miniproxy/remote_spec.rb
@@ -1,7 +1,7 @@
 require "miniproxy/remote"
 
 describe MiniProxy::Remote do
-  let(:remote) { MiniProxy::Remote.new }
+  let(:remote) { MiniProxy::Remote.new("127.0.0.1") }
 
   describe "#handler" do
     context "when the request has not been mocked" do

--- a/spec/lib/miniproxy/stub/request_spec.rb
+++ b/spec/lib/miniproxy/stub/request_spec.rb
@@ -30,5 +30,19 @@ RSpec.describe MiniProxy::Stub::Request do
         end
       end
     end
+
+    context "CONNECT requests" do
+      it "returns true when it matches the host" do
+        http_request = instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "google.com:443") 
+
+        expect(request.match?(http_request)).to eq(true)
+      end
+
+      it "returns false when it does not match the host" do
+        http_request = instance_double(WEBrick::HTTPRequest, request_method: "CONNECT", unparsed_uri: "example.com:443") 
+
+        expect(request.match?(http_request)).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
We have a scenario where we want particular domains to be permitted through the proxy as we want a real response rather than a mock. Since MiniProxy defaults to responding with an empty 200 when an unmocked request is made, we can't do that.

This adds an 'allow_request' option that takes a method and URL pattern. When a request is made that matches an allowed request it will be permitted through the proxy.

Requests for localhost, 127.0.0.1, and whatever the MiniProxy configured host is will continue to always be permitted.