### PR TITLE
Drop support for Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.7
   - 2.6
   - 2.5
-  - 2.4
 addons:
   firefox: "65.0"
 before_install:


### PR DESCRIPTION
Support for Ruby 2.4 ended in April this year, so Ruby 2.4 will no longer be supported for this gem anymore either.

https://www.ruby-lang.org/en/news/2020/04/05/support-of-ruby-2-4-has-ended/