### PR TITLE
Fix proxy method extensions in Ruby 2.6

### DIFF
--- a/lib/miniproxy/proxy_server.rb
+++ b/lib/miniproxy/proxy_server.rb
@@ -15,21 +15,35 @@ module MiniProxy
       super(config, default)
     end
 
-    def do_PUT(req, res)
-      perform_proxy_request(req, res) do |http, path, header|
-        http.put(path, req.body || "", header)
+    if RUBY_VERSION < "2.6.0"
+      def do_PUT(req, res)
+        perform_proxy_request(req, res) do |http, path, header|
+          http.put(path, req.body || "", header)
+        end
       end
-    end
 
-    def do_DELETE(req, res)
-      perform_proxy_request(req, res) do |http, path, header|
-        http.delete(path, header)
+      def do_DELETE(req, res)
+        perform_proxy_request(req, res) do |http, path, header|
+          http.delete(path, header)
+        end
       end
-    end
 
-    def do_PATCH(req, res)
-      perform_proxy_request(req, res) do |http, path, header|
-        http.patch(path, req.body || "", header)
+      def do_PATCH(req, res)
+        perform_proxy_request(req, res) do |http, path, header|
+          http.patch(path, req.body || "", header)
+        end
+      end
+    else
+      def do_PUT(req, res)
+        perform_proxy_request(req, res, Net::HTTP::Put, req.body_reader)
+      end
+
+      def do_DELETE(req, res)
+        perform_proxy_request(req, res, Net::HTTP::Delete)
+      end
+
+      def do_PATCH(req, res)
+        perform_proxy_request(req, res, Net::HTTP::Patch, req.body_reader)
       end
     end
 

--- a/spec/lib/miniproxy/proxy_server_spec.rb
+++ b/spec/lib/miniproxy/proxy_server_spec.rb
@@ -1,4 +1,5 @@
 require "miniproxy/proxy_server"
+require "support/server"
 
 RSpec.describe MiniProxy::ProxyServer do
   describe "#service" do
@@ -64,6 +65,56 @@ RSpec.describe MiniProxy::ProxyServer do
         it "calls the mock handler" do
           expect(handler).to receive(:call).with(req, res)
           proxy_server.service(req, res)
+        end
+      end
+    end
+  end
+
+  describe "passing through requests" do
+    it "suports GET requests" do
+      with_proxied_echo_server do |http|
+        req = Net::HTTP::Get.new("/")
+        http.request(req) do |res|
+          expect(res.body).to eq("GET / ")
+        end
+      end
+    end
+
+    it "suports POST requests" do
+      with_proxied_echo_server do |http|
+        req = Net::HTTP::Post.new("/")
+        req.body = "post-data"
+        http.request(req) do |res|
+          expect(res.body).to eq("POST / post-data")
+        end
+      end
+    end
+
+    it "suports PUT requests" do
+      with_proxied_echo_server do |http|
+        req = Net::HTTP::Put.new("/")
+        req.body = "put-data"
+        http.request(req) do |res|
+          expect(res.body).to eq("PUT / put-data")
+        end
+      end
+    end
+
+    it "suports PATCH requests" do
+      with_proxied_echo_server do |http|
+        req = Net::HTTP::Patch.new("/")
+        req.body = "patch-data"
+        http.request(req) do |res|
+          expect(res.body).to eq("PATCH / patch-data")
+        end
+      end
+    end
+
+    it "suports DELETE requests" do
+      with_proxied_echo_server do |http|
+        req = Net::HTTP::Delete.new("/")
+        http.request(req) do |res|
+          expect(res.body).to eq("DELETE / ")
         end
       end
     end

--- a/spec/support/server.rb
+++ b/spec/support/server.rb
@@ -1,0 +1,80 @@
+class EchoServlet < WEBrick::HTTPServlet::AbstractServlet
+  def echo(req, res)
+    res.body = "#{req.request_method} #{req.path} #{req.body}"
+  end
+
+  [:GET, :POST, :PUT, :PATCH, :DELETE].each do |m|
+    alias_method :"do_#{m}", :echo
+  end
+end
+
+def with_proxied_echo_server(config={}, &block)
+  start_server(WEBrick::HTTPServer) do |origin_server, origin_addr, origin_port|
+    origin_server.mount '/', EchoServlet
+
+    start_server(MiniProxy::ProxyServer, {
+      ProxyURI: URI.parse("http://#{origin_addr}:#{origin_port}"),
+      AllowedRequestCheck: ->(req) { true },
+      MockHandlerCallback: ->(req, res) { double(:handler) },
+    }.merge(config)) do |proxy_sever, proxy_addr, proxy_port|
+      yield Net::HTTP.new(origin_addr, origin_port, proxy_addr, proxy_port)
+    end
+  end
+end
+
+# The following methods are derived from
+# https://github.com/ruby/webrick/blob/4938ec3fae3ce32cceb685f6b8efff8926340c09/test/webrick/test_httpproxy.rb
+
+def start_server(klass, config={}, &block)
+  server = klass.new({
+    ServerType: Thread,
+    BindAddress: "127.0.0.1",
+    Port: 0,
+    Logger: WEBrick::Log.new([], WEBrick::BasicLog::WARN),
+    AccessLog: [],
+  }.merge(config))
+
+  server_thread = server.start
+
+  addr = server.listeners[0].addr
+
+  client_thread = Thread.new {
+    begin
+      block.yield([server, addr[3], addr[1]])
+    ensure
+      server.shutdown
+    end
+  }
+
+  assert_join_threads([client_thread, server_thread])
+end
+
+def assert_join_threads(threads, message = nil)
+  errs = []
+  values = []
+  while th = threads.shift
+    begin
+      values << th.value
+    rescue Exception
+      errs << [th, $!]
+      th = nil
+    end
+  end
+  values
+ensure
+  if th&.alive?
+    th.raise(Timeout::Error.new)
+    th.join rescue errs << [th, $!]
+  end
+  if !errs.empty?
+    msg = "exceptions on #{errs.length} threads:\n" +
+      errs.map {|t, err|
+      "#{t.inspect}:\n" +
+        err.full_message(highlight: false, order: :top)
+    }.join("\n---\n")
+    if message
+      msg = "#{message}\n#{msg}"
+    end
+    expect(msg).to eq("")
+  end
+end


### PR DESCRIPTION
In Ruby 2.6 the signature of `perform_proxy_request` has changed; it no longer takes two arguments and a block but now three or four arguments. This means the PUT, PATCH, and DELETE extensions made to the WEBrick HTTP proxy server do not work on Ruby 2.6.

This adds test coverage for each supported HTTP method and fixes the extensions.

https://github.com/ruby/webrick/blob/4938ec3fae3ce32cceb685f6b8efff8926340c09/lib/webrick/httpproxy.rb#L302