### PR TITLE
Fix pass-through of POST requests when interacting with webmock

### DIFF
--- a/lib/miniproxy/proxy_server.rb
+++ b/lib/miniproxy/proxy_server.rb
@@ -34,6 +34,10 @@ module MiniProxy
         end
       end
     else
+      def do_POST(req, res)
+        perform_proxy_request(req, res, Net::HTTP::Post, StringIO.new(req.body))
+      end
+
       def do_PUT(req, res)
         perform_proxy_request(req, res, Net::HTTP::Put, req.body_reader)
       end


### PR DESCRIPTION
**Why are we doing this?**
In donations, we'd like to test wallet payments (PR https://github.com/conversation/tc-donations/pull/1649), which involves sending a POST request to one of our endpoints through miniproxy. This POST request was failing with `NoMethodError`, which is interpreted by WEBrick as "POST method not implemented".

This was actually an incorrect classification; the `NoMethodError` wasn't caused by `do_POST` missing, but because of a different missing method.

In particular, webmock will attempt to call `#read` on the POST body stream:

https://github.com/bblimke/webmock/blob/master/lib/webmock/http_lib_adapters/net_http.rb#L331

By default, WEBrick will pass the `HTTPRequest` object here, which can't be read in the same way:

https://github.com/ruby/webrick/blob/master/lib/webrick/httpproxy.rb#L222
https://github.com/ruby/webrick/blob/master/lib/webrick/httprequest.rb#L265

I suspect this is a bug in webmock, but let's start with a fix within our control.

**Manual testing steps**
1. Modify https://github.com/conversation/tc-donations/pull/1649 to run on this version of miniproxy
2. Push to CI
3. The specs should pass