### PR TITLE
Add webrick as a dependency

### DIFF
--- a/miniproxy.gemspec
+++ b/miniproxy.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files -- lib/* ssl/*`.split("\n")
 
+  s.add_runtime_dependency 'webrick', '~> 1'
+
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'capybara', '~> 3.36'
   s.add_development_dependency 'selenium-webdriver', '~> 3.142'


### PR DESCRIPTION
As of Ruby 3.0, webrick is no longer bundled with Ruby, so it needs to be explicitly depended on.
