### PR TITLE
Update supported Ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.7', '3.0', '3.1']
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small stubbable proxy server for testing HTTP(S) interactions.
 
 ## Supported Versions
 
-* Ruby 2.6.x, 2.7.x
+* Ruby 2.7, 3.0, 3.1.
 
 ## Getting Started
 

--- a/miniproxy.gemspec
+++ b/miniproxy.gemspec
@@ -19,4 +19,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'capybara', '~> 3.36'
   s.add_development_dependency 'selenium-webdriver', '~> 3.142'
+  # no longer bundled with Ruby 3+, but required by selenium-webdriver, v3 of which does not explicitly depend on it
+  s.add_development_dependency 'rexml', '~> 3'
 end

--- a/miniproxy.gemspec
+++ b/miniproxy.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files -- lib/* ssl/*`.split("\n")
 
+  s.add_runtime_dependency 'webrick', '~> 1'
+
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'capybara', '~> 3.36'
   s.add_development_dependency 'selenium-webdriver', '~> 3.142'


### PR DESCRIPTION
Ruby 2.6 will be end-of-life in two weeks. Ruby 3.0 and 3.1 are out now, and we want to support them as we're migrating to 3.1.

https://endoflife.date/ruby
