### PR TITLE
Revert "Provide POST body as #read -able stream"

### DIFF
--- a/lib/miniproxy/proxy_server.rb
+++ b/lib/miniproxy/proxy_server.rb
@@ -34,10 +34,6 @@ module MiniProxy
         end
       end
     else
-      def do_POST(req, res)
-        perform_proxy_request(req, res, Net::HTTP::Post, StringIO.new(req.body))
-      end
-
       def do_PUT(req, res)
         perform_proxy_request(req, res, Net::HTTP::Put, req.body_reader)
       end

--- a/spec/lib/miniproxy/proxy_server_spec.rb
+++ b/spec/lib/miniproxy/proxy_server_spec.rb
@@ -118,43 +118,5 @@ RSpec.describe MiniProxy::ProxyServer do
         end
       end
     end
-
-    if RUBY_VERSION >= "2.6.0"
-      describe "compatibility with webmock" do
-        let(:proxy_server) {
-          MiniProxy::ProxyServer.new(
-            AllowedRequestCheck: ->(req) { false },
-            Port: (12345..32768).to_a.sample,
-            FakeServerPort: 33333,
-            MockHandlerCallback: double(:handler),
-            MiniproxyConfig: double(allow_external_requests: false)
-          )
-        }
-        let(:res) { MiniProxy::Stub::Response.new(headers: [], body: "") }
-        let(:req) do
-          WEBrick::HTTPRequest.new(WEBrick::Config::HTTP).tap do |req|
-            req.parse(StringIO.new(http_request))
-          end
-        end
-        let(:http_request) do
-          <<~HTTP
-            POST / HTTP/1.1
-            Host: localhost
-            Content-Type: application/json
-            Content-Length: 2
-
-            {}
-          HTTP
-        end
-
-        it "provides the POST body as a read-able stream" do
-          expect(proxy_server).to receive(:perform_proxy_request) do |req, res, req_class, body_stream|
-            expect(body_stream).to respond_to :read
-          end
-
-          proxy_server.do_POST(req, res)
-        end
-      end
-    end
   end
 end


### PR DESCRIPTION
#39 addressed a clash between webmock and miniproxy that prevented donations wallet specs from running, but was unfortunately [incompatible with TC](https://github.com/conversation/tc/pull/11735). We now have [a cleaner solution](https://github.com/conversation/tc-donations/pull/2021/files#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94) to prevent them from interfering with each other so we can revert this fix.
