### PR TITLE
Update supported Ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: browser-actions/setup-firefox@latest
         with:
-          firefox-version: '65.0'
+          firefox-version: '112.0'
 
       - name: Set up geckodriver
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1']
+        ruby-version: ['3.0', '3.1', '3.2']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           tar -xzf geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz -C geckodriver
           echo "$PWD/geckodriver" >> $GITHUB_PATH
         env:
-          GECKODRIVER_VERSION: 0.21.0
+          GECKODRIVER_VERSION: 0.33.0
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small stubbable proxy server for testing HTTP(S) interactions.
 
 ## Supported Versions
 
-* Ruby 2.7, 3.0, 3.1.
+* Ruby 3.0, 3.1, 3.2
 
 ## Getting Started
 


### PR DESCRIPTION
Ruby 2.7 is no longer supported, and Ruby 3.2 is now available.

https://endoflife.date/ruby
