### PR TITLE
Update README and GitHub actions dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         ruby-version: ['3.0', '3.1', '3.2']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.5.2
 
       - uses: browser-actions/setup-firefox@latest
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MiniProxy [![Build Status](https://travis-ci.org/conversation/miniproxy.svg?branch=master)](https://travis-ci.org/conversation/miniproxy)
+# MiniProxy
 
 A small stubbable proxy server for testing HTTP(S) interactions.
 


### PR DESCRIPTION
## Why?

* README: we are no longer using Travis CI to run `miniproxy` tests. We have replaced it with GitHub actions (see https://github.com/conversation/miniproxy/pull/41)
* `actions/checkout` update: version 2 has been marked as deprecated, so we're using the latest stable version, with its full semver tag reference
    * Deprecation warning: https://github.com/conversation/miniproxy/actions/runs/4819829646