### PR TITLE
Update supported Ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: browser-actions/setup-firefox@latest
         with:
-          firefox-version: '112.0'
+          firefox-version: '135.0'
 
       - name: Set up geckodriver
         run: |
@@ -24,7 +24,7 @@ jobs:
           tar -xzf geckodriver-v${GECKODRIVER_VERSION}-linux64.tar.gz -C geckodriver
           echo "$PWD/geckodriver" >> $GITHUB_PATH
         env:
-          GECKODRIVER_VERSION: 0.33.0
+          GECKODRIVER_VERSION: 0.35.0
 
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.2', '3.3', '3.4']
 
     steps:
       - uses: actions/checkout@v3.5.2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A small stubbable proxy server for testing HTTP(S) interactions.
 
 ## Supported Versions
 
-* Ruby 3.0, 3.1, 3.2
+* Ruby 3.2, 3.4, 3.4
 
 ## Getting Started
 

--- a/miniproxy.gemspec
+++ b/miniproxy.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'webrick', '~> 1'
 
   s.add_development_dependency 'rspec', '~> 3'
-  s.add_development_dependency 'capybara', '~> 3.36'
-  s.add_development_dependency 'selenium-webdriver', '~> 3.142'
-  # no longer bundled with Ruby 3+, but required by selenium-webdriver, v3 of which does not explicitly depend on it
-  s.add_development_dependency 'rexml', '~> 3'
+  s.add_development_dependency 'capybara', '~> 3'
+  s.add_development_dependency 'selenium-webdriver', '~> 4'
 end

--- a/miniproxy.gemspec
+++ b/miniproxy.gemspec
@@ -14,7 +14,10 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files -- lib/* ssl/*`.split("\n")
 
+  s.required_ruby_version = Gem::Requirement.new('>= 3.2', '< 4')
+
   s.add_runtime_dependency 'webrick', '~> 1'
+  s.add_runtime_dependency 'drb', '~> 2'
 
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'capybara', '~> 3'

--- a/spec/support/capybara_driver.rb
+++ b/spec/support/capybara_driver.rb
@@ -2,7 +2,7 @@ require "capybara"
 require "selenium-webdriver"
 
 firefox_profile = Selenium::WebDriver::Firefox::Profile.new
-firefox_profile.assume_untrusted_certificate_issuer = true
+firefox_profile.secure_ssl = false
 firefox_profile.proxy = Selenium::WebDriver::Proxy.new(
   http: "#{MiniProxy.host}:#{MiniProxy.port}",
   ssl: "#{MiniProxy.host}:#{MiniProxy.port}"
@@ -17,11 +17,11 @@ firefox_profile["privacy.trackingprotection.pbmode.enabled"] = false
 firefox_profile["plugins.flashBlock.enabled"] = false
 firefox_profile["browser.safebrowsing.blockedURIs.enable"] = false
 
-firefox_options = Selenium::WebDriver::Firefox::Options.new(profile: firefox_profile)
-firefox_options.headless!
-
-firefox_caps = Selenium::WebDriver::Remote::Capabilities.firefox(accept_insecure_certs: true)
+firefox_options = Selenium::WebDriver::Firefox::Options.new(
+  profile: firefox_profile,
+  args: ['-headless'],
+)
 
 Capybara.register_driver :firefox do |app|
-  Capybara::Selenium::Driver.new(app, desired_capabilities: firefox_caps, options: firefox_options)
+  Capybara::Selenium::Driver.new(app, options: firefox_options)
 end


### PR DESCRIPTION
Ruby 3.4 is out, 3.0 is no longer supported, and 3.1 won't be in a couple of months either.

https://endoflife.date/ruby
